### PR TITLE
Bug fix - translation/rotation messed up in meshes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 cmake-build-debug/
 cmake-build-default/
 cmake-build-release/
+testScenes/

--- a/collisionData.cpp
+++ b/collisionData.cpp
@@ -16,3 +16,11 @@ Color CollisionData::getColor() {
     return collidedObject->material->getColor();
 }
 
+bool CollisionData::isLight() {
+    return collidedObject->material->isLightSource;
+}
+
+Color CollisionData::getLight() {
+    return collidedObject->material->getLight();
+}
+

--- a/collisionData.h
+++ b/collisionData.h
@@ -27,6 +27,8 @@ public:
     Point3 location() const;
     Ray getNextRay();
     Color getColor();
+    bool isLight();
+    Color getLight();
 };
 
 #endif //COLLISIONDATA_H

--- a/hittableObject.cpp
+++ b/hittableObject.cpp
@@ -17,6 +17,46 @@ bool HittableObject::rayCollidesBoundingBox(const Ray& r) {
     return boundingBox.rayCollidesBox(r);
 }
 
+void HittableObject::setPosition(const Point3& pos) {
+    this->position = pos;
+}
+
+void HittableObject::movePosition(const Point3& delta) {
+    setPosition(position + delta);
+}
+
+void HittableObject::moveX(const float& deltaX) {
+    this->movePosition({deltaX, 0.f, 0.f});
+}
+
+void HittableObject::moveY(const float& deltaY) {
+    this->movePosition({0.f, deltaY, 0.f});
+}
+
+void HittableObject::moveZ(const float& deltaZ) {
+    this->movePosition({0.f, 0.f, deltaZ});
+}
+
+void HittableObject::setRotation(const Matrix3x3& rot) {
+    this->rotationMatrix = rot;
+}
+
+void HittableObject::rotate(const Matrix3x3& rot) {
+    this->setRotation(rot * rotationMatrix);
+}
+
+void HittableObject::rotateX(const float& theta) {
+    this->rotate(rotationX(theta));
+}
+
+void HittableObject::rotateY(const float& theta) {
+    this->rotate(rotationY(theta));
+}
+
+void HittableObject::rotateZ(const float& theta) {
+    this->rotate(rotationZ(theta));
+}
+
 Vec3 HittableObject::localToWorld(const Vec3& v) {
     return this->rotationMatrix * v + this->position;
 }

--- a/hittableObject.h
+++ b/hittableObject.h
@@ -28,6 +28,26 @@ public:
 
     virtual CollisionData rayCollisionPoint(const Ray& r) = 0;
 
+    virtual void setPosition(const Point3& pos);
+
+    void movePosition(const Point3& delta);
+
+    void moveX(const float& deltaX);
+
+    void moveY(const float& deltaY);
+
+    void moveZ(const float& deltaZ);
+
+    virtual void setRotation(const Matrix3x3& rot);
+
+    void rotate(const Matrix3x3& rot);
+
+    void rotateX(const float& theta);
+
+    void rotateY(const float& theta);
+
+    void rotateZ(const float& theta);
+
 protected:
     Vec3 localToWorld(const Vec3& v);
 };

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@
 #include "hittableObject.h"
 #include "material.h"
 
-const int NUM_BOUNCE = 15;
+const int NUM_BOUNCE = 10;
 const int NUM_BOUNCED_RAYS = 10;
 const int STOP_DIVIDING_AFTER_K_BOUNCES = 2;
 
@@ -31,6 +31,9 @@ CollisionData getCollision(const Ray& r, const std::vector<HittableObject*>& obj
 Color getColorFromRay(const Ray& r, const std::vector<HittableObject*>& objectList, const int& kthBounce) {
     CollisionData closestCollision = getCollision(r, objectList);
     if (closestCollision.collided) {
+        if (closestCollision.isLight()) {
+            return closestCollision.getLight();
+        }
         if (kthBounce < NUM_BOUNCE) {
             Color resultColor;
             if (kthBounce > STOP_DIVIDING_AFTER_K_BOUNCES) {
@@ -104,6 +107,13 @@ int main() {
     // Initialize Camera
     std::cout << "Initializing Camera ......" << std::endl;
     CameraSpec camera; // Use default constants
+
+
+    float yOffset = 2e5;
+    camera.moveY(yOffset);
+    for (auto targetObj: objectList) {
+        targetObj->moveY(yOffset);
+    }
 
     // User defined constants
     const int numPixelWidth = 640; // Arbitrary

--- a/material.cpp
+++ b/material.cpp
@@ -5,7 +5,8 @@ Material::Material() {
     color = Color(0.5f, 0.5f, 0.5f);
 }
 
-Material::Material(const Color& color): color(color) {}
+Material::Material(const Color& color, const bool& isLightSource)
+    : color(color), isLightSource(isLightSource) {}
 
 Ray Material::getNextRay(const CollisionData& collisionData) {
     //return {collisionData.location(), collisionData.r.direction() * (-1.f)};
@@ -21,5 +22,19 @@ Ray Material::getNextRay(const CollisionData& collisionData) {
 }
 
 Color Material::getColor() {
-    return color;
+    if (isLightSource) {
+        return {0.f, 0.f, 0.f};
+    }
+    else {
+        return color;
+    }
+}
+
+Color Material::getLight() {
+    if (isLightSource) {
+        return color;
+    }
+    else {
+        return {0.f, 0.f, 0.f};
+    }
 }

--- a/material.h
+++ b/material.h
@@ -9,15 +9,17 @@ class CollisionData;
 // Superclass is a default Material
 class Material {
 public:
+    bool isLightSource = false;
     Color color;
 
     Material();
-    Material(const Color& color);
+    Material(const Color& color, const bool& isLightSource=false);
 
     // Generate a ray probabilistically
     Ray getNextRay(const CollisionData& collisionData);
 
     Color getColor();
+    Color getLight();
 };
 
 

--- a/mesh.cpp
+++ b/mesh.cpp
@@ -61,22 +61,16 @@ CollisionData Mesh::rayCollisionPoint(const Ray& r) {
     }
 }
 
-void Mesh::rotateX(const float& theta) {
-    this->rotationMatrix = rotationX(theta) * this->rotationMatrix;
-    this->precomputeWorldCoords();
-    this->precomputeFaceProperties();
+void Mesh::setPosition(const Point3& pos) {
+    HittableObject::setPosition(pos);
+    precomputeWorldCoords();
+    precomputeFaceProperties();
 }
 
-void Mesh::rotateY(const float& theta) {
-    this->rotationMatrix = rotationY(theta) * this->rotationMatrix;
-    this->precomputeWorldCoords();
-    this->precomputeFaceProperties();
-}
-
-void Mesh::rotateZ(const float& theta) {
-    this->rotationMatrix = rotationZ(theta) * this->rotationMatrix;
-    this->precomputeWorldCoords();
-    this->precomputeFaceProperties();
+void Mesh::setRotation(const Matrix3x3& rot) {
+    HittableObject::setRotation(rot);
+    precomputeWorldCoords();
+    precomputeFaceProperties();
 }
 
 void Mesh::precomputeWorldCoords() {

--- a/mesh.h
+++ b/mesh.h
@@ -30,9 +30,8 @@ public:
 
     CollisionData rayCollisionPoint(const Ray& r);
 
-    void rotateX(const float& theta);
-    void rotateY(const float& theta);
-    void rotateZ(const float& theta);
+    void setPosition(const Point3& pos);
+    void setRotation(const Matrix3x3& rot);
 
 protected:
     // Precompute all Vertex World Coord


### PR DESCRIPTION
- Fixed the issue where translation/rotation are messed up in meshes, as the precomputed variables were not being updated when rotation/translation occurs.
- Added a basic light class. Although this is not related to this PR, I don't want to separate out the code just to create a new PR, so I am include the change as it is.