### PR TITLE
Add Scene and Sampler classes to tidy up raytracing main loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ set( RAYTRACER-BY-HAILEY-SRC
         boundingBox.h
         plyImport.cpp
         plyImport.h
+        sampler.h
+        scene.cpp
+        scene.h
+        utils.cpp
+        utils.h
 )
      
 add_executable( raytracer-by-hailey WIN32 ${RAYTRACER-BY-HAILEY-SRC} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set( RAYTRACER-BY-HAILEY-SRC
         scene.h
         utils.cpp
         utils.h
+        sampler.cpp
 )
      
 add_executable( raytracer-by-hailey WIN32 ${RAYTRACER-BY-HAILEY-SRC} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,12 @@ set( RAYTRACER-BY-HAILEY-SRC
         boundingBox.h
         plyImport.cpp
         plyImport.h
+        sampler.cpp
         sampler.h
         scene.cpp
         scene.h
         utils.cpp
         utils.h
-        sampler.cpp
 )
      
 add_executable( raytracer-by-hailey WIN32 ${RAYTRACER-BY-HAILEY-SRC} )

--- a/cameraSpec.h
+++ b/cameraSpec.h
@@ -2,7 +2,9 @@
 #define CAMERA_H
 
 #include "vec3.h"
+#include "ray.h"
 #include "matrix3x3.h"
+#include "sampler.h"
 
 class CameraSpec {
 public:
@@ -21,11 +23,11 @@ public:
         this->aspect_ratio = (this->sensorWidth)/(this->sensorHeight);
     }
 
-    Vec3 getDirection(const float& NDC_x, const float& NDC_y) const {
-        Point3 A = Point3(NDC_x, NDC_y, -1.f);
+    Ray getRay(const NdcPoint& ndcPoint, const int& screenWidth, const int& screenHeight) const {
+        Point3 A = Point3(ndcPoint.x, ndcPoint.y, -1.f);
         Point3 B = A * Point3(this->sensorWidth, this->sensorHeight, this->focal_length);
         Point3 rayScreenDirection = rotationMatrix * B;
-        return rayScreenDirection;
+        return {this->position, rayScreenDirection, 0};
     }
 
     void setPosition(const Point3& pos) {

--- a/collisionData.cpp
+++ b/collisionData.cpp
@@ -8,19 +8,19 @@ Point3 CollisionData::location() const {
     return r.at(t);
 }
 
-Ray CollisionData::getNextRay() {
+Ray CollisionData::getNextRay() const {
     return collidedObject->material->getNextRay(*this);
 }
 
-Color CollisionData::getColor() {
+Color CollisionData::getColor() const {
     return collidedObject->material->getColor();
 }
 
-bool CollisionData::isLight() {
+bool CollisionData::isLight() const {
     return collidedObject->material->isLightSource;
 }
 
-Color CollisionData::getLight() {
+Color CollisionData::getLight() const {
     return collidedObject->material->getLight();
 }
 

--- a/collisionData.h
+++ b/collisionData.h
@@ -25,10 +25,10 @@ public:
     CollisionData(const bool &collided = false) : collided(collided) {}
 
     Point3 location() const;
-    Ray getNextRay();
-    Color getColor();
-    bool isLight();
-    Color getLight();
+    Ray getNextRay() const;
+    Color getColor() const;
+    bool isLight() const;
+    Color getLight() const;
 };
 
 #endif //COLLISIONDATA_H

--- a/main.cpp
+++ b/main.cpp
@@ -9,79 +9,46 @@
 #include "hittableObject.h"
 #include "material.h"
 #include "plyImport.h"
+#include "sampler.h"
+#include "scene.h"
+#include "utils.h"
 
 const int NUM_BOUNCE = 15;
 const int NUM_BOUNCED_RAYS = 5;
 const int STOP_DIVIDING_AFTER_K_BOUNCES = 2;
 
-CollisionData getCollision(const Ray& r, const std::vector<HittableObject*>& objectList) {
-    // Compute closest collision
-    CollisionData closestCollision(false);
-    for (auto hittable : objectList) {
-        CollisionData coll = hittable->rayCollisionPoint(r);
-        if (!coll.collided) {
-            continue;
-        }
-        if (!closestCollision.collided || coll.t < closestCollision.t) {
-            closestCollision = coll;
-        }
-    }
-    return closestCollision;
-}
+Color raytrace(const Ray& r, Scene& scene) {
+    CollisionData closestCollision = scene.findClosestCollision(r);
 
-Color getColorFromRay(const Ray& r, const std::vector<HittableObject*>& objectList, const int& kthBounce) {
-    CollisionData closestCollision = getCollision(r, objectList);
-    if (closestCollision.collided) {
-        if (closestCollision.isLight()) {
-            return closestCollision.getLight();
-        }
-        if (kthBounce < NUM_BOUNCE) {
-            Color resultColor;
-            if (kthBounce > STOP_DIVIDING_AFTER_K_BOUNCES) {
-                Ray bouncedRay = closestCollision.getNextRay();
-                float bounceTheta = std::acos(dot(r.direction(), closestCollision.normal*(-1.f)) / (r.direction().length() * closestCollision.normal.length()));
-                Color collidedMaterialColor = closestCollision.getColor();
-                return collidedMaterialColor * getColorFromRay(bouncedRay, objectList, kthBounce+1);
-            }
-            for (int i = 0; i < NUM_BOUNCED_RAYS; i++) {
-                Ray bouncedRay = closestCollision.getNextRay();
-                float bounceTheta = std::acos(dot(r.direction(), closestCollision.normal*(-1.f)) / (r.direction().length() * closestCollision.normal.length()));
-                Color collidedMaterialColor = closestCollision.getColor();
-                //resultColor += collidedMaterialColor * getColorFromRay(bouncedRay, objectList, kthBounce+1) * std::cos(bounceTheta);
-                resultColor += collidedMaterialColor * getColorFromRay(bouncedRay, objectList, kthBounce+1);
-            }
-            resultColor /= (float)NUM_BOUNCED_RAYS;
-            return resultColor;
-        }
-        else {
-            return {0.f, 0.f, 0.f};
-        }
-    }
-    else {
-        // skybox collision
+    if (!closestCollision.collided) {
         return {200.f/255.999f, 244.f/255.999f, 255.f/255.999f};
     }
-}
-
-Color runRaytracing(const CameraSpec& camera, const std::vector<HittableObject*>& objectList, const float& NDC_x, const float& NDC_y) {
-    // Create initial Ray r
-    Ray r(camera.position, camera.getDirection(NDC_x, NDC_y));
-
-    return getColorFromRay(r, objectList, 0);
+    else if (closestCollision.isLight()) {
+        return closestCollision.getLight();
+    }
+    else {
+        std::vector<Ray> bouncedRays = scene.getBouncedRays(closestCollision,
+            NUM_BOUNCE, NUM_BOUNCED_RAYS, STOP_DIVIDING_AFTER_K_BOUNCES);
+        if (bouncedRays.empty()) {
+            return {0.f, 0.f, 0.f};
+        }
+        Color resultColor;
+        for (Ray br: bouncedRays) {
+            Color bouncedColor = raytrace(br, scene);
+            float cosTheta = calculateRaySurfaceCosAngle(br, closestCollision.normal);
+            resultColor += closestCollision.getColor() * bouncedColor * cosTheta;
+        }
+        resultColor /= (float)bouncedRays.size();
+        return resultColor;
+    }
 }
 
 std::pair<int, int> getWindowDim(const CameraSpec& camera, const int& numPixelWidth) {
-    return std::pair<int, int>(numPixelWidth,
-                               std::round((float)numPixelWidth * camera.sensorHeight / camera.sensorWidth));
+    return {numPixelWidth, std::round((float)numPixelWidth * camera.sensorHeight / camera.sensorWidth)};
 }
 
 int main() {
     std::srand(std::time(nullptr));
-    GLFWwindow* window;
-
-    if (!glfwInit()) {
-        exit(EXIT_FAILURE);
-    }
 
     // Material creation
     Material grayMaterial;
@@ -92,85 +59,87 @@ int main() {
     Material yellowMaterial(Color(0.9f, 0.9f, 0.45f));
 
     // Initialize objects
-    std::vector<HittableObject*> objectList;
+    Scene scene;
     std::string fileName = "../data/bun_zipper_res2.ply";
     Mesh bunnyMesh = plyImport::read(fileName, whiteMaterial);
     bunnyMesh.moveZ(-0.20f);
     bunnyMesh.moveY(-0.1f);
     bunnyMesh.moveX(0.045f);
-    objectList.push_back(&bunnyMesh);
+    scene.objectList.push_back(&bunnyMesh);
 
     Cube cube1(Point3(1.f, 0.f, -1.3f), Matrix3x3(), 0.5f, 0.6f, 0.55f, &purpleMaterial);
     cube1.rotateX(-2.f);
-    objectList.push_back(&cube1);
+    scene.objectList.push_back(&cube1);
     Cube cube2(Point3(-0.7f, 0.f, -1.1f), Matrix3x3(), 0.7f, 0.6f, 0.3f, &redMaterial);
     cube2.rotateZ(-1.2f);
-    objectList.push_back(&cube2);
+    scene.objectList.push_back(&cube2);
     Cube cube3(Point3(0.f, -0.47f, 0.f), Matrix3x3(), 50.f, 0.2f, 50.f, &blueMaterial);
-    objectList.push_back(&cube3);
+    scene.objectList.push_back(&cube3);
     Sphere sphere2(Point3(-3.8f, 0.f, -0.5f), Matrix3x3(), 3.f, &yellowMaterial);
-    objectList.push_back(&sphere2);
+    scene.objectList.push_back(&sphere2);
 
     // Initialize Camera
     std::cout << "Initializing Camera ......" << std::endl;
     CameraSpec camera; // Use default constants
 
     // User defined constants
-    const int numPixelWidth = 640; // Arbitrary
-
-    // Compute desired number of pixels
+    // Since ratio is determined by the camera specifications, window height is not configurable
+    const int numPixelWidth = 640;
     const std::pair<int, int> windowDim = getWindowDim(camera, numPixelWidth);
 
     // Create window
     std::cout << "Creating Window ......" << std::endl;
+    if (!glfwInit()) {
+        exit(EXIT_FAILURE);
+    }
+    GLFWwindow* window;
     window = glfwCreateWindow(windowDim.first, windowDim.second, "Raytracer by Hailey", NULL, NULL);
     if (!window) {
         glfwTerminate();
         exit(EXIT_FAILURE);
     }
-
-    // Make Context
     glfwMakeContextCurrent(window);
 
-    float ratio;
+    // Read actual resolution from created window
     int width, height;
-
     glfwGetFramebufferSize(window, &width, &height);
-    ratio = (float)width / (float)height;
     std::cout << "framebuffer sizes: width " << width << ", height " << height << std::endl;
 
     // Set background color to viewport
     glViewport(0, 0, width, height);
     glClear(GL_COLOR_BUFFER_BIT);
 
-    // Raytracing loop
     std::cout << "Starting Raytracing ......" << std::endl;
-    // Begin mode: draw points
-    for (int j = 2*height-1; j >= 0; j--) {
-        glBegin(GL_POINTS);
-        for (int i = 0; i < 2*width; i++) {
-            // Compute NDC (Normalized Device Coordinates)
-            float NDC_x = (float)i/(float)width-1.f; // [-1, 1]
-            float NDC_y = (float)j/(float)height-1.f; // [-1, 1]
 
-            // Get color from NDC coordinates
-            Color c = runRaytracing(camera, objectList, NDC_x, NDC_y);
+    // Generate Sample points on screen
+    Sampler sampler;
+    std::vector<NdcPoint> samplePoints = sampler.createSamplePoints(width, height);
 
-            // Draw point in color
-            glColor3f(c.x(),c.y(),c.z());
-            glVertex2f(NDC_x,NDC_y);
-        }
-        // End mode: draw points
-        glEnd();
-        glfwPollEvents();
-        glfwSwapBuffers(window);
+    // Raytracing loop
+    glBegin(GL_POINTS);
+    int counter = 0;
+    for (auto s: samplePoints) {
+        Ray r = camera.getRay(s, width, height);
+        Color c = raytrace(r, scene);
+        // Draw point in color
+        glColor3f(c.x(),c.y(),c.z());
+        glVertex2f(s.x,s.y);
+
+        counter++;
+
+
+        /*if (counter%10000 == 0) {
+            glEnd();
+            glfwPollEvents();
+            glfwSwapBuffers(window);
+            glBegin(GL_POINTS);
+        }*/
     }
-
-    std::cout << "Rendering done!" << std::endl;
-
-    // Swap front/back buffers
+    // End mode: draw points
+    glEnd();
     glfwPollEvents();
     glfwSwapBuffers(window);
+    std::cout << "Rendering done!" << std::endl;
 
     // Wait until the window is closed
     while (!glfwWindowShouldClose(window)) {
@@ -179,7 +148,6 @@ int main() {
 
     // Destroy window
     std::cout << "Closing window ......" << std::endl;
-
     glfwDestroyWindow(window);
     glfwTerminate();
     exit(EXIT_SUCCESS);

--- a/main.cpp
+++ b/main.cpp
@@ -126,14 +126,6 @@ int main() {
         glVertex2f(s.x,s.y);
 
         counter++;
-
-
-        /*if (counter%10000 == 0) {
-            glEnd();
-            glfwPollEvents();
-            glfwSwapBuffers(window);
-            glBegin(GL_POINTS);
-        }*/
     }
     // End mode: draw points
     glEnd();

--- a/main.cpp
+++ b/main.cpp
@@ -36,7 +36,7 @@ Color raytrace(const Ray& r, Scene& scene) {
         for (Ray br: bouncedRays) {
             Color bouncedColor = raytrace(br, scene);
             float cosTheta = calculateRaySurfaceCosAngle(br, closestCollision.normal);
-            resultColor += closestCollision.getColor() * bouncedColor * cosTheta;
+            resultColor += closestCollision.getColor() * bouncedColor;// * cosTheta;
         }
         resultColor /= (float)bouncedRays.size();
         return resultColor;

--- a/material.cpp
+++ b/material.cpp
@@ -18,7 +18,7 @@ Ray Material::getNextRay(const CollisionData& collisionData) {
     if (dot(direction, collisionData.normal) < 0.f) {
         direction = direction * (-1.f);
     }
-    return {collisionData.location(), direction};
+    return {collisionData.location(), direction, collisionData.r.kthBounce+1};
 }
 
 Color Material::getColor() {

--- a/ray.h
+++ b/ray.h
@@ -14,7 +14,8 @@ class Ray {
 public:
     Ray() {}
 
-    Ray(const Point3& origin, const Vec3& direction) : orig(origin), dir(direction/direction.length()) {}
+    Ray(const Point3& origin, const Vec3& direction, const int& kthBounce)
+        : orig(origin), dir(direction/direction.length()), kthBounce(kthBounce) {}
 
     Point3 origin() const { return orig; }
     Vec3 direction() const { return dir; }
@@ -22,6 +23,8 @@ public:
     Point3 at(float t) const {
         return orig + t*dir;
     }
+
+    int kthBounce;
 
 private:
     Point3 orig;

--- a/sampler.cpp
+++ b/sampler.cpp
@@ -1,0 +1,17 @@
+#include "sampler.h"
+
+// Create points on screen that rays would be initiated from
+// Uniform sampling by default; Override in derived class
+std::vector<NdcPoint> Sampler::createSamplePoints(const int& width, const int& height) {
+    std::vector<NdcPoint> samplePoints;
+    samplePoints.reserve(width * height);
+    for (int j = height-1; j >= 0; j--) {
+        for (int i = 0; i < width; i++) {
+            float x = ((float)i + 0.5f) * 2.f / (float)width - 1.f;
+            float y = ((float)j + 0.5f) * 2.f / (float)height - 1.f;
+            samplePoints.emplace_back(x, y);
+        }
+    }
+
+    return samplePoints;
+}

--- a/sampler.h
+++ b/sampler.h
@@ -1,0 +1,31 @@
+#ifndef SAMPLER_H
+#define SAMPLER_H
+
+#include <vector>
+
+struct NdcPoint {
+    float x; // in [-1, 1]
+    float y; // in [-1, 1]
+    NdcPoint(const float& x, const float& y) : x(x), y(y) {}
+};
+
+class Sampler {
+public:
+    // Create points on screen that rays would be initiated from
+    // Uniform sampling by default; Override in derived class
+    virtual std::vector<NdcPoint> createSamplePoints(const int& width, const int& height) {
+        std::vector<NdcPoint> samplePoints;
+        samplePoints.reserve(width * height);
+        for (int j = height-1; j >= 0; j--) {
+            for (int i = 0; i < width; i++) {
+                float x = ((float)i + 0.5f) * 2.f / (float)width - 1.f;
+                float y = ((float)j + 0.5f) * 2.f / (float)height - 1.f;
+                samplePoints.emplace_back(x, y);
+            }
+        }
+
+        return samplePoints;
+    }
+};
+
+#endif //SAMPLER_H

--- a/sampler.h
+++ b/sampler.h
@@ -13,19 +13,7 @@ class Sampler {
 public:
     // Create points on screen that rays would be initiated from
     // Uniform sampling by default; Override in derived class
-    virtual std::vector<NdcPoint> createSamplePoints(const int& width, const int& height) {
-        std::vector<NdcPoint> samplePoints;
-        samplePoints.reserve(width * height);
-        for (int j = height-1; j >= 0; j--) {
-            for (int i = 0; i < width; i++) {
-                float x = ((float)i + 0.5f) * 2.f / (float)width - 1.f;
-                float y = ((float)j + 0.5f) * 2.f / (float)height - 1.f;
-                samplePoints.emplace_back(x, y);
-            }
-        }
-
-        return samplePoints;
-    }
+    virtual std::vector<NdcPoint> createSamplePoints(const int& width, const int& height);
 };
 
 #endif //SAMPLER_H

--- a/scene.cpp
+++ b/scene.cpp
@@ -1,0 +1,2 @@
+
+#include "scene.h"

--- a/scene.cpp
+++ b/scene.cpp
@@ -1,2 +1,34 @@
-
 #include "scene.h"
+
+CollisionData Scene::findClosestCollision(const Ray &r) const {
+    CollisionData closestCollision(false);
+    for (auto hittable: this->objectList) {
+        CollisionData coll = hittable->rayCollisionPoint(r);
+        if (!coll.collided) {
+            continue;
+        }
+        if (!closestCollision.collided || coll.t < closestCollision.t) {
+            closestCollision = coll;
+        }
+    }
+    return closestCollision;
+}
+
+std::vector<Ray> Scene::getBouncedRays(const CollisionData &closestCollision,
+                                const int &NUM_BOUNCE, const int &NUM_BOUNCED_RAYS,
+                                const int &STOP_DIVIDING_AFTER_K_BOUNCES) const {
+    std::vector<Ray> bouncedRays;
+    int kthBounce = closestCollision.r.kthBounce+1;
+    if (kthBounce > NUM_BOUNCE) {
+        // do nothing
+    }
+    else if (kthBounce > STOP_DIVIDING_AFTER_K_BOUNCES) {
+        bouncedRays.push_back(closestCollision.getNextRay());
+    }
+    else {
+        for (int i = 0; i < NUM_BOUNCED_RAYS; i++) {
+            bouncedRays.push_back(closestCollision.getNextRay());
+        }
+    }
+    return bouncedRays;
+}

--- a/scene.h
+++ b/scene.h
@@ -8,38 +8,11 @@ class Scene {
 public:
     std::vector<HittableObject *> objectList;
 
-    CollisionData findClosestCollision(const Ray &r) const {
-        CollisionData closestCollision(false);
-        for (auto hittable: this->objectList) {
-            CollisionData coll = hittable->rayCollisionPoint(r);
-            if (!coll.collided) {
-                continue;
-            }
-            if (!closestCollision.collided || coll.t < closestCollision.t) {
-                closestCollision = coll;
-            }
-        }
-        return closestCollision;
-    }
+    CollisionData findClosestCollision(const Ray &r) const;
 
     std::vector<Ray> getBouncedRays(const CollisionData &closestCollision,
                                     const int &NUM_BOUNCE, const int &NUM_BOUNCED_RAYS,
-                                    const int &STOP_DIVIDING_AFTER_K_BOUNCES) const {
-        std::vector<Ray> bouncedRays;
-        int kthBounce = closestCollision.r.kthBounce+1;
-        if (kthBounce > NUM_BOUNCE) {
-            // do nothing
-        }
-        else if (kthBounce > STOP_DIVIDING_AFTER_K_BOUNCES) {
-            bouncedRays.push_back(closestCollision.getNextRay());
-        }
-        else {
-            for (int i = 0; i < NUM_BOUNCED_RAYS; i++) {
-                bouncedRays.push_back(closestCollision.getNextRay());
-            }
-        }
-        return bouncedRays;
-    }
+                                    const int &STOP_DIVIDING_AFTER_K_BOUNCES) const;
 };
 
 

--- a/scene.h
+++ b/scene.h
@@ -1,0 +1,46 @@
+#ifndef SCENE_H
+#define SCENE_H
+
+#include <vector>
+#include "hittableObject.h"
+
+class Scene {
+public:
+    std::vector<HittableObject *> objectList;
+
+    CollisionData findClosestCollision(const Ray &r) const {
+        CollisionData closestCollision(false);
+        for (auto hittable: this->objectList) {
+            CollisionData coll = hittable->rayCollisionPoint(r);
+            if (!coll.collided) {
+                continue;
+            }
+            if (!closestCollision.collided || coll.t < closestCollision.t) {
+                closestCollision = coll;
+            }
+        }
+        return closestCollision;
+    }
+
+    std::vector<Ray> getBouncedRays(const CollisionData &closestCollision,
+                                    const int &NUM_BOUNCE, const int &NUM_BOUNCED_RAYS,
+                                    const int &STOP_DIVIDING_AFTER_K_BOUNCES) const {
+        std::vector<Ray> bouncedRays;
+        int kthBounce = closestCollision.r.kthBounce+1;
+        if (kthBounce > NUM_BOUNCE) {
+            // do nothing
+        }
+        else if (kthBounce > STOP_DIVIDING_AFTER_K_BOUNCES) {
+            bouncedRays.push_back(closestCollision.getNextRay());
+        }
+        else {
+            for (int i = 0; i < NUM_BOUNCED_RAYS; i++) {
+                bouncedRays.push_back(closestCollision.getNextRay());
+            }
+        }
+        return bouncedRays;
+    }
+};
+
+
+#endif //SCENE_H

--- a/utils.cpp
+++ b/utils.cpp
@@ -1,0 +1,7 @@
+#include "utils.h"
+
+float calculateRaySurfaceCosAngle(const Ray& r, const Vec3& n) {
+    float dotProd = dot(r.direction(), n*(-1.f));
+    float dotProdNormalized = dotProd / (r.direction().length() * n.length());
+    return dotProdNormalized;
+}

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,9 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include "vec3.h"
+#include "ray.h"
+
+float calculateRaySurfaceCosAngle(const Ray& r, const Vec3& n);
+
+#endif //UTILS_H


### PR DESCRIPTION
Mostly tidying up the main function before bringing in OpenGL pipeline and compute shaders.
- Create Sampler class (Base class with Uniform sampling only)
- Create Scene class (Tidy up collision testing and ray bouncing)
- 'hittableObjects' container is now inside Scene class, not main()
- Add 'utils' file to tidy up formulas and logic
- Camera returns a starting Ray instead of starting direction
- Number of bounce is now tracked within a ray (not in raytracing loop)
- C++ style: added 'const' to constant functions

